### PR TITLE
feat: Base CodeId on a binary buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 
 use std::error;
 use std::fmt;
-use std::fmt::Write;
 use std::str;
 
 use regex::Regex;
@@ -64,8 +63,13 @@ impl fmt::Display for ParseDebugIdError {
 
 /// Unique identifier for debug information files and their debug information.
 ///
-/// The string representation must be between 33 and 40 characters long and
-/// consist of:
+/// This type is analogous to `CodeId`, except that it identifies a debug file instead of the actual
+/// library or executable. One some platforms, a `DebugId` is an alias for a `CodeId` but the exact
+/// rules around this are complex. On Windows, the identifiers are completely different and refer to
+/// separate files.
+///
+/// The string representation must be between 33 and 40 characters
+/// long and consist of:
 ///
 /// 1. 36 character hyphenated hex representation of the UUID field
 /// 2. 1-16 character lowercase hex representation of the u32 appendix
@@ -274,51 +278,9 @@ impl fmt::Display for ParseCodeIdError {
 ///    lowercase hex string.
 ///  - **PE Timestamp**: Timestamp and size of image values from a Windows PE header.
 ///  - **GO Build ID**: Nested GO build identifiers comprising `actionID/[.../]contentID`.
-///
-/// One some platforms a `CodeId` is an alias for a `DebugId` but the exact rules
-/// around this are complex.  Because of this the `CodeId` type provides a helper
-/// that effectively parses the `CodeId` as if it was a hexadecimal ID and lets
-/// you access the underlying bytes.  You should only use this method when you are
-/// sure that the ID you're dealing with is compatible.
-///
-/// Because the `CodeId` does not really have a format it also means that the
-/// hex derived bytes representation is largely a guess and is lossy.  For instance
-/// the underlying bytes will not make a difference between the ID `fafa` and `FAFA`.
 #[derive(Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CodeId {
-    inner: String,
-    bytes: Option<Vec<u8>>,
-}
-
-fn debug_id_as_bytes(id: &str) -> Option<Vec<u8>> {
-    let mut rv = Vec::new();
-
-    let mut half = None;
-    for &c in id.as_bytes().iter() {
-        half = match (c, half) {
-            (b'-', h) => h,
-            (b'0'..=b'9', Some(h)) => {
-                rv.push((h << 4) | (c - b'0'));
-                None
-            }
-            (b'0'..=b'9', None) => Some(c - b'0'),
-            (b'a'..=b'f', Some(h)) => {
-                rv.push((h << 4) | (c - b'a' + 10));
-                None
-            }
-            (b'a'..=b'f', None) => Some(c - b'a' + 10),
-            (b'A'..=b'F', Some(h)) => {
-                rv.push((h << 4) | (c - b'A' + 10));
-                None
-            }
-            (b'A'..=b'F', None) => Some(c - b'A' + 10),
-            _ => {
-                return None;
-            }
-        }
-    }
-
-    Some(rv)
+    inner: Vec<u8>,
 }
 
 impl CodeId {
@@ -327,26 +289,30 @@ impl CodeId {
         Self::default()
     }
 
-    /// Constructs a `CodeId` from its string representation.
-    pub fn new(string: String) -> Self {
-        CodeId {
-            bytes: debug_id_as_bytes(&string),
-            inner: string,
-        }
+    /// Constructs a `CodeId` from a binary buffer.
+    pub fn from_vec(vec: Vec<u8>) -> Self {
+        CodeId { inner: vec }
     }
 
     /// Constructs a `CodeId` from a binary slice.
-    pub fn from_binary(slice: &[u8]) -> Self {
-        let mut string = String::with_capacity(slice.len() * 2);
+    pub fn from_slice(slice: &[u8]) -> Self {
+        Self::from_vec(slice.into())
+    }
 
-        for byte in slice {
-            write!(&mut string, "{:02x}", byte).expect("");
+    /// Parses a `CodeId` from a hexadecimal string.
+    pub fn parse_hex(string: &str) -> Result<Self, ParseCodeIdError> {
+        if string.len() % 2 != 0 {
+            return Err(ParseCodeIdError);
         }
 
-        CodeId {
-            inner: string,
-            bytes: Some(slice.to_vec()),
-        }
+        let vec = string
+            .as_bytes()
+            .chunks(2)
+            .map(|chunk| u8::from_str_radix(unsafe { str::from_utf8_unchecked(chunk) }, 16))
+            .collect::<Result<_, _>>()
+            .map_err(|_| ParseCodeIdError)?;
+
+        Ok(Self::from_vec(vec))
     }
 
     /// Returns whether this identifier is nil, i.e. it is empty.
@@ -354,31 +320,30 @@ impl CodeId {
         self.inner.is_empty()
     }
 
-    /// Returns the string representation of this code identifier.
-    pub fn as_str(&self) -> &str {
-        self.inner.as_str()
-    }
-
-    /// The bytes if the code id is in a compatible hexadecimal format.
-    pub fn as_bytes(&self) -> Option<&[u8]> {
-        self.bytes.as_ref().map(|bytes| &bytes[..])
+    /// Returns the binary representation of this code identifier.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.inner
     }
 
     /// If this `DebugId` holds a UUID, return it.
     pub fn uuid(&self) -> Option<Uuid> {
-        self.as_bytes().and_then(|b| Uuid::from_slice(b).ok())
+        Uuid::from_slice(&self.inner).ok()
     }
 }
 
 impl fmt::Display for CodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.inner)
+        for byte in &self.inner {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
     }
 }
 
 impl fmt::Debug for CodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("CodeId").field(&self.as_str()).finish()
+        write!(f, "CodeId({})", self)
     }
 }
 
@@ -386,7 +351,19 @@ impl str::FromStr for CodeId {
     type Err = ParseCodeIdError;
 
     fn from_str(string: &str) -> Result<Self, ParseCodeIdError> {
-        Ok(Self::new(string.into()))
+        Self::parse_hex(string)
+    }
+}
+
+impl From<Vec<u8>> for CodeId {
+    fn from(vec: Vec<u8>) -> Self {
+        CodeId::from_vec(vec)
+    }
+}
+
+impl From<&'_ [u8]> for CodeId {
+    fn from(slice: &[u8]) -> Self {
+        CodeId::from_slice(slice)
     }
 }
 
@@ -399,14 +376,15 @@ mod serde_support {
 
     impl Serialize for CodeId {
         fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            serializer.serialize_str(self.as_str())
+            serializer.serialize_str(&self.to_string())
         }
     }
 
     impl<'de> Deserialize<'de> for CodeId {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             let string = String::deserialize(deserializer)?;
-            Ok(CodeId::new(string))
+            CodeId::parse_hex(&string)
+                .map_err(|_| de::Error::invalid_value(Unexpected::Str(&string), &"CodeId"))
         }
     }
 

--- a/tests/test_codeid.rs
+++ b/tests/test_codeid.rs
@@ -1,15 +1,29 @@
 use debugid::CodeId;
+use uuid::Uuid;
 
 #[test]
 fn test_new() {
     let id = CodeId::new("dfb8e43af2423d73a453aeb6a777ef75".into());
     assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75");
+    assert_eq!(
+        id.as_bytes(),
+        Some(&b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75"[..])
+    );
+    assert_eq!(
+        id.uuid(),
+        Some(Uuid::parse_str("dfb8e43a-f242-3d73-a453-aeb6a777ef75").unwrap())
+    );
 }
 
 #[test]
 fn test_case_sensitive() {
     let id = CodeId::new("dfb8e43af2423d73a453aeb6a777ef75FFFFFF".into());
     assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75FFFFFF");
+    // on the other hand, bytes ignore capitalization
+    assert_eq!(
+        id.as_bytes(),
+        Some(&b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75\xff\xff\xff"[..])
+    );
 }
 
 #[test]
@@ -17,6 +31,7 @@ fn test_from_binary() {
     let binary = b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75";
     let id = CodeId::from_binary(&binary[..]);
     assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75");
+    assert_eq!(id.as_bytes(), Some(&binary[..]));
 }
 
 #[test]

--- a/tests/test_codeid.rs
+++ b/tests/test_codeid.rs
@@ -3,11 +3,11 @@ use uuid::Uuid;
 
 #[test]
 fn test_new() {
-    let id = CodeId::new("dfb8e43af2423d73a453aeb6a777ef75".into());
-    assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75");
+    let id = CodeId::parse_hex("dfb8e43af2423d73a453aeb6a777ef75").unwrap();
+    assert_eq!(id.to_string(), "dfb8e43af2423d73a453aeb6a777ef75");
     assert_eq!(
-        id.as_bytes(),
-        Some(&b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75"[..])
+        id.as_slice(),
+        &b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75"[..]
     );
     assert_eq!(
         id.uuid(),
@@ -16,26 +16,15 @@ fn test_new() {
 }
 
 #[test]
-fn test_case_sensitive() {
-    let id = CodeId::new("dfb8e43af2423d73a453aeb6a777ef75FFFFFF".into());
-    assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75FFFFFF");
-    // on the other hand, bytes ignore capitalization
-    assert_eq!(
-        id.as_bytes(),
-        Some(&b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75\xff\xff\xff"[..])
-    );
-}
-
-#[test]
 fn test_from_binary() {
     let binary = b"\xdf\xb8\xe4\x3a\xf2\x42\x3d\x73\xa4\x53\xae\xb6\xa7\x77\xef\x75";
-    let id = CodeId::from_binary(&binary[..]);
-    assert_eq!(id.as_str(), "dfb8e43af2423d73a453aeb6a777ef75");
-    assert_eq!(id.as_bytes(), Some(&binary[..]));
+    let id = CodeId::from_slice(&binary[..]);
+    assert_eq!(id.to_string(), "dfb8e43af2423d73a453aeb6a777ef75");
+    assert_eq!(id.as_slice(), &binary[..]);
 }
 
 #[test]
 fn test_is_nil() {
-    let id = CodeId::new(String::new());
+    let id = CodeId::nil();
     assert!(id.is_nil());
 }

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -30,7 +30,7 @@ fn test_serialize_debugid() {
 #[test]
 fn test_deserialize_codeid() {
     assert_eq!(
-        CodeId::new("dfb8e43af2423d73a453aeb6a777ef75".into()),
+        CodeId::parse_hex("dfb8e43af2423d73a453aeb6a777ef75").unwrap(),
         serde_json::from_str("\"dfb8e43af2423d73a453aeb6a777ef75\"").unwrap(),
     );
 }
@@ -39,6 +39,7 @@ fn test_deserialize_codeid() {
 fn test_serialize_codeid() {
     assert_eq!(
         "\"dfb8e43af2423d73a453aeb6a777ef75\"",
-        serde_json::to_string(&CodeId::new("dfb8e43af2423d73a453aeb6a777ef75".into())).unwrap(),
+        serde_json::to_string(&CodeId::parse_hex("dfb8e43af2423d73a453aeb6a777ef75").unwrap())
+            .unwrap(),
     );
 }


### PR DESCRIPTION
This keeps the behavior more or less the same as far as the `CodeId` is concerned but allows the user to interpret the `CodeId` in bytes if necessary. Theoretically the bytes could be computed on the fly but I don't think there is much value in this.

The usecase here is that for instance in the symbolicator most code paths need to parse and interpret a code id in the underlying bytes to format it out in different ways.