### PR TITLE
ref: Remove lazy_static and regex dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ edition = "2018"
 
 [dependencies]
 uuid = "0.8.1"
-regex = "1.1.0"
-lazy_static = "1.2.0"
 serde = { version = "1.0.85", optional = true }
 
 [dev-dependencies]

--- a/tests/test_debugid.rs
+++ b/tests/test_debugid.rs
@@ -113,6 +113,11 @@ fn test_parse_error_short() {
 }
 
 #[test]
+fn test_parse_error_trailing_dash() {
+    assert!(DebugId::from_str("dfb8e43a-f242-3d73-a453-aeb6a777ef75-").is_err());
+}
+
+#[test]
 fn test_from_guid_age() {
     let guid = [
         0x98, 0xd1, 0xef, 0xe8, 0x6e, 0xf8, 0xfe, 0x45, 0x9d, 0xdb, 0xe1, 0x13, 0x82, 0xb5, 0xd1,
@@ -160,13 +165,12 @@ fn test_parse_breakpad_long() {
 
 #[test]
 fn test_parse_breakpad_with_tail() {
-    assert_eq!(
-        DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75feedface123").unwrap(),
-        DebugId::from_parts(
-            Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
-            0xfeed_face,
-        )
-    );
+    assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75feedface123").is_err());
+}
+
+#[test]
+fn test_parse_breakpad_missing_age() {
+    assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75").is_err());
 }
 
 #[test]

--- a/tests/test_debugid.rs
+++ b/tests/test_debugid.rs
@@ -118,6 +118,11 @@ fn test_parse_error_trailing_dash() {
 }
 
 #[test]
+fn test_parse_error_unicode() {
+    assert!(DebugId::from_str("아이쿱 조합원 앱카드").is_err());
+}
+
+#[test]
 fn test_from_guid_age() {
     let guid = [
         0x98, 0xd1, 0xef, 0xe8, 0x6e, 0xf8, 0xfe, 0x45, 0x9d, 0xdb, 0xe1, 0x13, 0x82, 0xb5, 0xd1,
@@ -164,13 +169,23 @@ fn test_parse_breakpad_long() {
 }
 
 #[test]
-fn test_parse_breakpad_with_tail() {
+fn test_parse_breakpad_error_tail() {
     assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75feedface123").is_err());
 }
 
 #[test]
-fn test_parse_breakpad_missing_age() {
+fn test_parse_breakpad_error_missing_age() {
     assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75").is_err());
+}
+
+#[test]
+fn test_parse_breakpad_error_short() {
+    assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF7").is_err());
+}
+
+#[test]
+fn test_parse_breakpad_error_dashes() {
+    assert!(DebugId::from_breakpad("e8efd198-f86e-45fe-9ddb-e11382b5d1c9-1").is_err());
 }
 
 #[test]
@@ -210,11 +225,6 @@ fn test_to_string_breakpad_long() {
         id.breakpad().to_string(),
         "DFB8E43AF2423D73A453AEB6A777EF75feedface"
     );
-}
-
-#[test]
-fn test_parse_breakpad_error_short() {
-    assert!(DebugId::from_breakpad("DFB8E43AF2423D73A453AEB6A777EF7").is_err());
 }
 
 #[test]


### PR DESCRIPTION
Implements a manual parser instead of relying on regexes. Mostly still delegates to the UUID parser, except for parsing the appendix. 

As opposed to the previous parser, this implementation is stricter:
- Either everything is hyphenated or nothing.
- Trailing dashes are never allowed.
- Breakpad format only allows Breakpad ids and requires an age.