### PR TITLE
ref: Bump MSRV due to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: SUITE=lint
     - env: SUITE=test
     - env: SUITE=test
-      rust: "1.31.0"
+      rust: "1.36.0"
 
 notifications:
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.3
 
-- Bump Minimal Stable Rust Version to 1.36 due to dependencies.
+- Bump Minimal Supported Rust Version to 1.36 due to dependencies.
 
 ## 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.3
+
+- Bump Minimal Stable Rust Version to 1.36 due to dependencies.
+
 ## 0.7.2
 
 - Implement stricter and more consistent validation in `FromStr for DebugId`.


### PR DESCRIPTION
The itoa dependency (via serde_json) now requires Rust 1.36+.