### PR TITLE
ref(pdb20): Move type byte to end of struct, rename construtor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,8 @@ struct ParseOptions {
 pub struct DebugId {
     bytes: Bytes,
     appendix: u32,
-    typ: u8,
     _padding: [u8; 11],
+    typ: u8,
 }
 
 impl DebugId {
@@ -168,7 +168,7 @@ impl DebugId {
     }
 
     /// Constructs a `DebugId` from a PDB 2.0 timestamp and age.
-    pub fn from_timestamp_age(timestamp: u32, age: u32) -> Self {
+    pub fn from_pdb20(timestamp: u32, age: u32) -> Self {
         // The big-endian byte-order here has to match the one used to read this number in
         // the DebugId::timestamp method.
         DebugId {
@@ -191,8 +191,8 @@ impl DebugId {
                 0u8,
             ],
             appendix: age,
-            typ: 1u8,
             _padding: [0u8; 11],
+            typ: 1u8,
         }
     }
 
@@ -232,7 +232,7 @@ impl DebugId {
 
     /// Returns whether this identifier is nil, i.e. it consists only of zeros.
     pub fn is_nil(&self) -> bool {
-        self.bytes.iter().all(|&b| b == 0) && self.appendix == 0
+        self.bytes == [0u8; 16] && self.appendix == 0
     }
 
     /// Returns whether this identifier is from the PDB 2.0 format.
@@ -263,7 +263,7 @@ impl DebugId {
                 false => string.get(8..)?,
             };
             let appendix = u32::from_str_radix(appendix_str, 16).ok()?;
-            return Some(Self::from_timestamp_age(timestamp, appendix));
+            return Some(Self::from_pdb20(timestamp, appendix));
         }
 
         let uuid_len = if is_hyphenated { 36 } else { 32 };

--- a/tests/test_debugid.rs
+++ b/tests/test_debugid.rs
@@ -274,7 +274,7 @@ fn test_serde_deserialize() {
 fn test_pdb20() {
     let timestamp: u32 = 0x418e89c3;
     let age: u32 = 1;
-    let debug_id = DebugId::from_timestamp_age(timestamp, age);
+    let debug_id = DebugId::from_pdb20(timestamp, age);
 
     assert!(debug_id.is_pdb20());
     assert_eq!(
@@ -287,7 +287,7 @@ fn test_pdb20() {
 fn test_pdb20_format() {
     let timestamp: u32 = 0x418e89c3;
     let age: u32 = 1;
-    let debug_id = DebugId::from_timestamp_age(timestamp, age);
+    let debug_id = DebugId::from_pdb20(timestamp, age);
 
     assert_eq!(debug_id.to_string(), "418E89C3-1".to_string());
     assert_eq!(debug_id.breakpad().to_string(), "418E89C31");
@@ -297,7 +297,7 @@ fn test_pdb20_format() {
 fn test_pdb20_parse() {
     let timestamp: u32 = 0x418e89c3;
     let age: u32 = 1;
-    let debug_id = DebugId::from_timestamp_age(timestamp, age);
+    let debug_id = DebugId::from_pdb20(timestamp, age);
 
     let s = "418E89C3-1";
     let parsed = DebugId::from_str(s).unwrap();


### PR DESCRIPTION
Moving the type byte to the end is possibly slightly more future proof
as it allows other bytes which are a part of the identifier itself to
still be inserted in between.

Renaming the constructor is, well, bikeshedding.  But it matches
.is_pdb20() so why not.

#skip-changelog