### PR TITLE
fix(craft): Do not require artifacts when publishing

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,17 +1,10 @@
 # Configuration for sentry-craft (https://github.com/getsentry/craft)
-minVersion: "0.23.1"
+minVersion: "0.28.0"
 changelogPolicy: auto
-github:
-  owner: getsentry
-  repo: rust-debugid
+
+artifactProvider:
+  name: none
+
 targets:
   - name: crates
   - name: github
-preReleaseCommand: bash scripts/bump-version.sh
-statusProvider:
-  name: github
-artifactProvider:
-  name: github
-requireNames:
-  - /^.*\.zip$/
-  - /^.*\.tar\.gz$/


### PR DESCRIPTION
Changes the artifact provider to "none" and removes required artifacts, since
rust-debugid is published without. Additionally, removes defaults from the
craft config to align it with how we use craft in
Relay and Symbolicator.

#skip-changelog

